### PR TITLE
Fix bug when paginating through frolodex responses

### DIFF
--- a/lib/frederick_api/v2/helpers/requestor.rb
+++ b/lib/frederick_api/v2/helpers/requestor.rb
@@ -56,7 +56,7 @@ module FrederickAPI
 
           path_without_params = "#{uri.scheme}://#{uri.host}#{uri.path}"
           params = uri.query ? CGI.parse(uri.query).each_with_object({}) { |(k, v), h| h[k] = v[0] } : {}
-          request(:post, path_without_params, params: params, additional_headers: { 'X-Request-Method' => 'GET' })
+          request(:post, path_without_params, body: params.to_json, additional_headers: { 'X-Request-Method' => 'GET' })
         end
 
         # Retry once on unhandled server errors

--- a/lib/frederick_api/version.rb
+++ b/lib/frederick_api/version.rb
@@ -2,5 +2,5 @@
 
 module FrederickAPI
   # Current gem version
-  VERSION = '0.8'
+  VERSION = '0.9'
 end

--- a/spec/frederick_api/v2/helpers/requestor_spec.rb
+++ b/spec/frederick_api/v2/helpers/requestor_spec.rb
@@ -110,7 +110,7 @@ describe FrederickAPI::V2::Helpers::Requestor do
           it 'posts to get response without primary key in params' do
             expect(requestor.linked(url)).to be response
             expect(requestor).to have_received(:request)
-                                   .with(:post, path, params: expected_params, additional_headers: headers)
+                                   .with(:post, path, body: expected_params.to_json, additional_headers: headers)
           end
         end
 
@@ -125,7 +125,7 @@ describe FrederickAPI::V2::Helpers::Requestor do
           it 'posts to get response without primary key in params' do
             expect(requestor.linked(url)).to be response
             expect(requestor).to have_received(:request)
-                                   .with(:post, path, params: expected_params, additional_headers: headers)
+                                   .with(:post, path, body: expected_params.to_json, additional_headers: headers)
           end
         end
       end


### PR DESCRIPTION
Prior to this fix, the JSON API client would properly POST instead of GET for specific endpoints, but would post with query params instead of the post body as JSON, in this situation.